### PR TITLE
Add '"' after the key2 in the JSON example

### DIFF
--- a/docs/beginner/3.json.md
+++ b/docs/beginner/3.json.md
@@ -14,7 +14,7 @@ This is an example of a JSON file.
   "collapsed": false,
   "object": {
     "key1": "hey",
-    "key2: ["test",1,2,3]
+    "key2": ["test",1,2,3]
   },
   "arrayKey": [],
   "nullValue": null


### PR DESCRIPTION
- Updated the JSON example to be correctly validated.
- Changed ->  "key2: ["test",1,2,3] ->  "key2": ["test",1,2,3]